### PR TITLE
Delete duplicated foreign key migration

### DIFF
--- a/db/migrate/20221003212156_add_user_ref_to_foods.rb
+++ b/db/migrate/20221003212156_add_user_ref_to_foods.rb
@@ -1,5 +1,0 @@
-class AddUserRefToFoods < ActiveRecord::Migration[7.0]
-  def change
-    add_reference :foods, :user, null: false, foreign_key: true
-  end
-end


### PR DESCRIPTION
- Remove the migration to create a user's foreign key to the foods table.